### PR TITLE
Add support for Macedonian official transliteration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Library for transliteration for cyrillic languages.
 ### Bulgarian language
 
 1. Official Bulgarian Streamlined System
+
+### Macedonian language
+
+1. Official Documents/Cadastre Digraph System

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ mod gost779;
 mod passport2013;
 mod transliterator;
 mod bulgarian;
+mod macedonian;
 
 #[cfg(test)]
 mod tests;
@@ -10,5 +11,6 @@ pub use gost779::*;
 pub use passport2013::*;
 pub use transliterator::*;
 pub use bulgarian::*;
+pub use macedonian::*;
 
 pub type CharsMapping = Vec<(&'static str, &'static str)>;

--- a/src/macedonian.rs
+++ b/src/macedonian.rs
@@ -37,7 +37,7 @@ pub fn digraph_system() -> CharsMapping {
         ("Х", "H"),
         ("Ц", "C"),
         ("Ч", "Ch"),
-        ("Џ", "Dz"),
+        ("Џ", "Dj"),
         ("Ш", "Sh"),
         ("а", "a"),
         ("б", "b"),
@@ -68,7 +68,7 @@ pub fn digraph_system() -> CharsMapping {
         ("х", "h"),
         ("ц", "c"),
         ("ч", "ch"),
-        ("џ", "dz"),
+        ("џ", "dj"),
         ("ш", "sh"),
     ].iter()
         .cloned()

--- a/src/macedonian.rs
+++ b/src/macedonian.rs
@@ -1,0 +1,76 @@
+use super::CharsMapping;
+
+/// Official system for transliterating Macedonian
+///
+/// more details:
+/// [Romanization of Macedonian #Digraph system](https://en.wikipedia.org/wiki/Romanization_of_Macedonian#Digraph_system)
+///
+/// Attention: Converting back from romanized cyrillic to cyrillic is ambiguous, thus not supported
+pub fn digraph_system() -> CharsMapping {
+    [
+        ("А", "A"),
+        ("Б", "B"),
+        ("В", "V"),
+        ("Г", "G"),
+        ("Д", "D"),
+        ("Ѓ", "Gj"),
+        ("Е", "E"),
+        ("Ж", "Zh"),
+        ("З", "Z"),
+        ("Ѕ", "Dz"),
+        ("И", "I"),
+        ("Ј", "J"),
+        ("К", "K"),
+        ("Л", "L"),
+        ("Љ", "Lj"),
+        ("М", "M"),
+        ("Н", "N"),
+        ("Њ", "Nj"),
+        ("О", "O"),
+        ("П", "P"),
+        ("Р", "R"),
+        ("С", "S"),
+        ("Т", "T"),
+        ("Ќ", "Kj"),
+        ("У", "U"),
+        ("Ф", "F"),
+        ("Х", "H"),
+        ("Ц", "C"),
+        ("Ч", "Ch"),
+        ("Џ", "Dz"),
+        ("Ш", "Sh"),
+        ("а", "a"),
+        ("б", "b"),
+        ("в", "v"),
+        ("г", "g"),
+        ("д", "d"),
+        ("ѓ", "gj"),
+        ("е", "e"),
+        ("ж", "zh"),
+        ("з", "z"),
+        ("ѕ", "dz"),
+        ("и", "i"),
+        ("ј", "j"),
+        ("к", "k"),
+        ("л", "l"),
+        ("љ", "lj"),
+        ("м", "m"),
+        ("н", "n"),
+        ("њ", "nj"),
+        ("о", "o"),
+        ("п", "p"),
+        ("р", "r"),
+        ("с", "s"),
+        ("т", "t"),
+        ("ќ", "kj"),
+        ("у", "u"),
+        ("ф", "f"),
+        ("х", "h"),
+        ("ц", "c"),
+        ("ч", "ch"),
+        ("џ", "dz"),
+        ("ш", "sh"),
+    ].iter()
+        .cloned()
+        .collect()
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use super::{FromLatin, Gost779B, Language, Passport2013, ToLatin, BulgarianOfficial};
+use super::{FromLatin, Gost779B, Language, Passport2013, ToLatin, BulgarianOfficial,MacedonianOfficial};
 
 // Russian
 const SOURCE_RU: &'static str =
@@ -122,4 +122,13 @@ const TRANSLIT_BG: &'static str = "Vsichki hora se razhdat svobodni i ravni po d
 #[test]
 fn test_bulgarian_to_latin() {
     assert_eq!(BulgarianOfficial::new().to_latin(SOURCE_BG), TRANSLIT_BG);
+}
+
+//Macedonian
+const SOURCE_MK: &'static str = "Природата ништо не прави бесцелно. Енергијата на умот е суштината на животот.";
+const TRANSLIT_MK: &'static str = "Prirodata nishto ne pravi bescelno. Energijata na umot e sushtinata na zhivotot.";
+
+#[test]
+fn test_macedonian_to_latin() {
+    assert_eq!(MacedonianOfficial::new().to_latin(SOURCE_MK), TRANSLIT_MK);
 }

--- a/src/transliterator.rs
+++ b/src/transliterator.rs
@@ -5,6 +5,7 @@ use std::cmp::Ordering;
 use gost779;
 use passport2013;
 use bulgarian;
+use macedonian;
 
 /// The contract for transliteration in the Latin alphabet
 pub trait ToLatin {
@@ -192,7 +193,7 @@ impl ToLatin for Passport2013 {
 }
 
 /// Official system for transliterating Bulgarian
-/// 
+///
 /// more details:
 /// [Romanization of Bulgarian #Streamlined system](https://en.wikipedia.org/wiki/Romanization_of_Bulgarian#Streamlined_System)
 ///
@@ -221,6 +222,41 @@ impl BulgarianOfficial {
 }
 
 impl ToLatin for BulgarianOfficial {
+    fn to_latin(&self, src: &str) -> String {
+        self.translit.to_latin(src)
+    }
+}
+
+/// Official system for transliterating Macedonian
+///
+/// more details:
+/// [Romanization of Macedonian #Digraph system](https://en.wikipedia.org/wiki/Romanization_of_Macedonian#Digraph_system)
+///
+/// Attention: Converting back from romanized cyrillic to cyrillic is ambiguous, thus not supported
+///
+/// # Examples
+///
+/// ```rust
+///
+/// use translit::{MacedonianOfficial, ToLatin};
+/// let trasliterator = MacedonianOfficial::new();
+/// let res = trasliterator.to_latin("Надзор");
+/// assert_eq!("Nadzor", res);
+///
+/// ```
+pub struct MacedonianOfficial {
+    translit: Transliterator,
+}
+
+impl MacedonianOfficial {
+    pub fn new() -> MacedonianOfficial {
+        let translit = Transliterator::new(macedonian::digraph_system());
+
+        MacedonianOfficial { translit }
+    }
+}
+
+impl ToLatin for MacedonianOfficial {
     fn to_latin(&self, src: &str) -> String {
         self.translit.to_latin(src)
     }


### PR DESCRIPTION
Adds support for the Macedonian digraph system used in official documents such as passports, ID cards, driver's licenses.